### PR TITLE
Non topsky LPPC ASR

### DIFF
--- a/LPPC/ASR/LPPC_CTR_TS.asr
+++ b/LPPC/ASR/LPPC_CTR_TS.asr
@@ -1,8 +1,8 @@
 DisplayTypeName:Standard ES radar screen
 DisplayTypeNeedRadarContent:1
 DisplayTypeGeoReferenced:1
-SECTORFILE:C:\Program Files (x86)\EuroScope\LPPC-Package_20200323020218-200301-0010.sct
-SECTORTITLE:LPPC-Package_20200323020218-200301-0010.sct
+SECTORFILE:C:\Program Files (x86)\EuroScope\LPPC-Package_20200322124616-200301-0005.sct
+SECTORTITLE:LPPC-Package_20200322124616-200301-0005.sct
 Airports:LPBG:symbol
 Airports:LPBR:symbol
 Airports:LPCO:symbol
@@ -17,20 +17,6 @@ Airports:LPVL:symbol
 Airports:LPVR:symbol
 Airports:LPVZ:symbol
 ARTCC boundary:COBERTURA RADAR:
-ARTCC boundary:LPP2 Prohibited area:
-ARTCC boundary:LPR26A Restricted area:
-ARTCC boundary:LPR40A Restricted area:
-ARTCC boundary:LPR40BN Restricted area:
-ARTCC boundary:LPR40BS Restricted area:
-ARTCC boundary:LPR42A Restricted area:
-ARTCC boundary:LPR42B Restricted area:
-ARTCC boundary:LPR44A Restricted area:
-ARTCC boundary:LPR51A Restricted area:
-ARTCC boundary:LPR51BN Restricted area:
-ARTCC boundary:LPR51BS Restricted area:
-ARTCC boundary:LPR51C Restricted area:
-ARTCC boundary:LPR60A Restricted area:
-ARTCC boundary:LPR60B Restricted area:
 ARTCC boundary:SECTOR CENTRE UPPER:
 ARTCC boundary:SECTOR DEMOS:
 ARTCC boundary:SECTOR EAST:
@@ -384,14 +370,6 @@ Geo:LE Landmark Spain Coastline:
 Geo:LP Landmark Continental Coastline:
 Geo:LP Landmark Madeira Coastline:
 Geo:LP Landmark Porto Santo Coastline:
-Geo:LPBJ Groundlayout:
-Geo:LPCS Groundlayout:
-Geo:LPEV Groundlayout:
-Geo:LPFR Groundlayout:
-Geo:LPMA Groundlayout:
-Geo:LPPR Groundlayout:
-Geo:LPPS Groundlayout:
-Geo:LPPT Groundlayout:
 NDBs:BJA:symbol
 NDBs:CB:symbol
 NDBs:EVR:symbol
@@ -400,10 +378,6 @@ NDBs:MIO:symbol
 NDBs:PST:symbol
 NDBs:STR:symbol
 NDBs:VR:symbol
-Regions:LPFR Groundlayout:polygon
-Regions:LPMA Groundlayout:polygon
-Regions:LPPR Groundlayout:polygon
-Regions:LPPT Groundlayout:polygon
 Runways:LPAR 04-22:centerline
 Runways:LPBJ 01L-19R:centerline
 Runways:LPBJ 01L-19R:extended centerline 1
@@ -460,7 +434,7 @@ VORs:VFA:symbol
 VORs:VIS:symbol
 SHOWC:1
 SHOWSB:1
-BELOW:0
+BELOW:500
 ABOVE:66000
 LEADER:-2
 SHOWLEADER:1
@@ -471,4 +445,4 @@ DISABLEPANNING:0
 DISABLEZOOMING:0
 DisplayRotation:0.00000
 TAGFAMILY:PT vACC - NORM
-WINDOWAREA:35.314412:-20.925754:43.456252:-1.861033
+WINDOWAREA:38.411708:-10.030036:39.111087:-8.392388

--- a/LPPC_CTR.prf
+++ b/LPPC_CTR.prf
@@ -1,0 +1,25 @@
+Settings	sector	\LPPC-Package_20200323020218-200301-0010.sct
+RecentFiles	Recent1	\LPPC\ASR\LPPC_CTR.asr
+Settings	alias	\LPPC\Alias\alias.txt
+Settings	airlines	\LPPC\ICAO\ICAO_Airlines.txt
+Settings	airports	\LPPC\ICAO\ICAO_Airports.txt
+Settings	aircraft	\LPPC\ICAO\ICAO_Aircraft.txt
+Settings	Settingsfile	\LPPC\Settings\General.txt
+Settings	AtisFolder	\LPPC\ATIS\atisfiles.txt
+Settings	SettingsfileSYMBOLOGY	\LPPC\Settings\Symbology.txt
+Settings	SettingsfileVOICE	\LPPC\Settings\VoiceChannels.txt
+Settings	SettingsfilePROFILE	\LPPC\Settings\Settings.txt
+Settings	SettingsfileTAGS	\LPPC\Settings\Tags.txt
+Settings	SettingsfileSIL	\LPPC\Settings\SectorInboundList.txt
+Settings	SettingsfileSEL	\LPPC\Settings\SectorExitList.txt
+Settings	SettingsfileDEP	\LPPC\Settings\DepartureList.txt
+Settings	SettingsfileARR	\LPPC\Settings\ArrivalList.txt
+Settings	SettingsfileFP	\LPPC\Settings\FPList.txt
+Settings	SettingsfilePLUGINS	\LPPC\Settings\Plugins.txt
+Settings	SettingsfileSCREEN	\LPPC\Settings\Screen.txt
+Settings	SettingsfileCONFLICT	\LPPC\Settings\Conflict.txt
+Settings	SettingsfileVCCS	\LPPC\Settings\General.txt
+Plugins	Plugin0	\AfvEuroScopeBridge.dll
+Plugins	Plugin0Display0	Standard ES radar screen
+Plugins	Plugin1	\ESTagItems.dll
+Plugins	Plugin1Display0	Standard ES radar screen

--- a/LPPC_CTR_TS.prf
+++ b/LPPC_CTR_TS.prf
@@ -1,4 +1,4 @@
-Settings	sector	\LPPC-Package_20200129154612-200101-0002.sct
+Settings	sector	\LPPC-Package_20200322124616-200301-0005.sct
 Settings	alias	\LPPC\Alias\alias.txt
 Settings	airlines	\LPPC\ICAO\ICAO_Airlines.txt
 Settings	airports	\LPPC\ICAO\ICAO_Airports.txt
@@ -29,15 +29,13 @@ Settings	FreqKey	3604480
 Voice	PPPT	18677760
 Settings	ipaddr	\ipaddr.txt
 Settings	airways	\LPPC\NavData\airway.txt
-ASRFastKeys	1	\LPPC\ASR\LPPC_CTR.asr
+ASRFastKeys	1	\LPPC\ASR\LPPC_CTR_TS.asr
 ASRFastKeys	2	\LPPC\ASR\LPMA_APP.asr
 ASRFastKeys	3	\LPPC\ASR\LPFR_APP.asr
 ASRFastKeys	4	\LPPC\ASR\LPPT_APP.asr
-ASRFastKeys	5	\LPPC\ASR\LPPR_APP.asr
+ASRFastKeys	5	\LPPC\ASR\LPCS_TWR.asr
 ASRFastKeys	6	\LPPC\ASR\LPMA_TWR.asr
 ASRFastKeys	7	\LPPC\ASR\LPFR_TWR.asr
 ASRFastKeys	8	\LPPC\ASR\LPPT_GND_TSGR.asr
 ASRFastKeys	9	\LPPC\ASR\LPPR_TWR.asr
-Plugins	Plugin2	\afv bridge\AfvEuroScopeBridge.dll
-Plugins	Plugin2Display0	Ground Radar display
-Plugins	Plugin2Display1	Standard ES radar screen
+Settings	SettingsfilePILOTING	\LPPC\Settings\General_TopSky.txt


### PR DESCRIPTION
some people asked to see things as they used to be. 

Renames LPPC_CTR.asr to LPPC_CTR_TS.asr for TopSky use only. No changes made to it. 
Adds a LPPC_CTR.asr for use WITHOUT TopSky only. Lets you see planes on the ground if you really want to and has the MCTR and MCTAs showing.

Added an LPCS_TWR asr to the hotkeys, it's F1+5