### PR TITLE
Reverts to default shortcuts

### DIFF
--- a/LPPC/Plugins/topsky/TopSkySettings.txt
+++ b/LPPC/Plugins/topsky/TopSkySettings.txt
@@ -191,30 +191,10 @@ RwyAppLines_Auto=0
 RwyAppLines_Length=18
 
 Shortcut_AHDG_NoFixes_Combo=0x00
-
-Shortcut_FPL_Combo=0x12
-Shortcut_FPL=0x7A
-
-Shortcut_FPL_Search_Combo=0x12
-Shortcut_FPL_Search=0x78
-
-Shortcut_QDM_Combo=0x12
-Shortcut_QDM=0x74
-
 Shortcut_XQDM_Combo=0x00
 Shortcut_XQDM=0x00
-
-Shortcut_Quick_Look_Combo=0x12
-Shortcut_Quick_Look=0x75
-
 Shortcut_Flight_Leg_Combo=0x00
 Shortcut_Flight_Leg=0x00
-
-Shortcut_SEP_Combo=0x12
-Shortcut_SEP=0x73
-
-Shortcut_Cursor_Ini_Combo=0x12
-Shortcut_Cursor_Ini=0x70
 
 System_ASP_IasMach=28500
 System_UseAcceptedCoordColor=1


### PR DESCRIPTION
Reverts to default shortcuts
Keeps FLeg and XQDM binds disabled as not available in TOPLIS
fixes #331 