### PR TITLE
Fixes CARD, MTCD and RAM limits and settings

### DIFF
--- a/LPPC/Plugins/topsky/TopSkySettings.txt
+++ b/LPPC/Plugins/topsky/TopSkySettings.txt
@@ -87,6 +87,8 @@ FlightLeg_AutoShow=1
 FlightLeg_AssumeTime=2
 FlightLeg_LineWidth=1
 
+FPCP_MinState=0
+
 HTTP_SIGMET_Pages=6443,6450
 
 HTTP_METAR_Server=https://meteo.ambitio.cyou/

--- a/LPPC/Plugins/topsky/TopSkySettings.txt
+++ b/LPPC/Plugins/topsky/TopSkySettings.txt
@@ -376,7 +376,7 @@ Label_No_FCOPX=0
 [_W_CTR]
 MTCD_Sep_Lat=10
 
-[_O_CTR]
+[_WU_CTR]
 MTCD_Sep_Lat=10
 
 [_I_CTR]

--- a/LPPC/Plugins/topsky/TopSkySettings.txt
+++ b/LPPC/Plugins/topsky/TopSkySettings.txt
@@ -76,7 +76,7 @@ CPDLC_PDC_PlaySound=1
 CPDLC_PDC_Timeout_Pilot=180
 CPDLC_FSM_CLD_Header=CLD <hour><min> <year2><month2><day> <adep2> PDC <number> <callsign>
 
-Divergence_RAM_Limit=3
+Divergence_RAM_Limit=1
 
 FlightLeg_Label_Time=1
 FlightLeg_Label_Point=0
@@ -224,6 +224,7 @@ MTCD_PLC_Time=5
 MTCD_Potential_Pred_Risk=1
 MTCD_Sep_Vert_U=2000
 MTCD_Sep_Vert_L=1000
+MTCD_Sep_Lat=7
 
 Rings_Separation=5
 Rings_Number=10
@@ -372,6 +373,12 @@ Label_No_NRAC=0
 Label_No_TSSR=0
 Label_No_FCOPX=0
 
+[_W_CTR]
+MTCD_Sep_Lat=10
+
+[_O_CTR]
+MTCD_Sep_Lat=10
+
 [_I_CTR]
 STCA_Coarse_Sep_Lat_U=8
 STCA_Coarse_Sep_Lat_L=8
@@ -379,6 +386,7 @@ STCA_LinPred_Sep_Lat_U=7.5
 STCA_LinPred_Sep_Lat_L=7.5
 STCA_CurrProx_Sep_Lat_U=7.75
 STCA_CurrProx_Sep_Lat_L=7.75
+MTCD_Sep_Lat=10
 
 [LPMA_]
 STCA_Coarse_Sep_Lat_U=8
@@ -387,6 +395,7 @@ STCA_LinPred_Sep_Lat_U=7.5
 STCA_LinPred_Sep_Lat_L=7.5
 STCA_CurrProx_Sep_Lat_U=7.75
 STCA_CurrProx_Sep_Lat_L=7.75
+MTCD_Sep_Lat=10
 
 [LPPR_APP]
 CPDLC_Default=1
@@ -402,6 +411,7 @@ STCA_LinPred_Sep_Lat_U=2.5
 STCA_LinPred_Sep_Lat_L=2.5
 STCA_CurrProx_Sep_Lat_U=2.75
 STCA_CurrProx_Sep_Lat_L=2.75
+MTCD_Sep_Lat=5
 
 [LPPT_U_APP]
 CPDLC_Default=1
@@ -413,6 +423,7 @@ STCA_LinPred_Sep_Lat_U=2.5
 STCA_LinPred_Sep_Lat_L=2.5
 STCA_CurrProx_Sep_Lat_U=2.75
 STCA_CurrProx_Sep_Lat_L=2.75
+MTCD_Sep_Lat=5
 
 [LPPT_]
 Window_CPDLC_Current=1,700,25


### PR DESCRIPTION
- [x] Fixes #522
- [x] Fixes #520

Sets MTCD limit to 10nm for W and O while keeping STCA limits based on 5nm sep to avoid nuisance alerts

Sets LPPT APP and F MTCD to 5nm to reduce nuisance alerts