### PR TITLE
Adds a way to remove DUPE for live traffic data

### DIFF
--- a/LPPC/Plugins/topsky/TopSkySettings.txt
+++ b/LPPC/Plugins/topsky/TopSkySettings.txt
@@ -27,7 +27,7 @@ Airspace_ASSR_Type=2
 Airspace_ASSR_OAT_Remarks=RMK/OAT
 Airspace_ASSR_OAT_Type=0
 Airspace_P_Flag=LPPR,LPPT,LPFR,LPMA,LPPS
-Airspace_No_DUPE_Codes=2000,7000
+Airspace_No_DUPE_Codes=2000,7000,0000
 Airspace_NOTAM_Add=LPPC,LECM
 Airspace_SIGMET_Areas=LPPC
 


### PR DESCRIPTION
Adds 0000 to the list of no dupes to avoid annoying DUPE warning while watching FR24 data