### PR TITLE
Disables realMode

### DIFF
--- a/LPPC/Plugins/ACDM/CDMconfig.xml
+++ b/LPPC/Plugins/ACDM/CDMconfig.xml
@@ -5,7 +5,7 @@
 	<rateLvo ops="12" />
 	<expiredCtot time="15" />
 	<ReaMsg minutes="0" />
-	<realMode mode="true" />
+	<realMode mode="false" />
 	<Taxizones url="" />
 	<Ctot url="" />
 	<DefaultTaxiTime minutes="15" />


### PR DESCRIPTION
Due to controller feedback, disables realMode as default to avoid blocks in TSAT due to pilots not complying with updated TOBT and to facilitate controller swaps