### PR TITLE
LPPR AD - A-SMGCS DOWNGRADED

### DIFF
--- a/LPPC/Plugins/GroundRadar/GRpluginSettings.txt
+++ b/LPPC/Plugins/GroundRadar/GRpluginSettings.txt
@@ -186,6 +186,11 @@ List_Alerts=1,1351,25
 List_Stand=0,1102,25
 List_Stand_Items=20
 
+System_APM=0
+System_RIM=0
+System_RUM=0 
+System_RVM=0
+
 Window_APP=1,700,25,410,410
 Window_APP_Extensions=0
 Window_APP_Scale=14


### PR DESCRIPTION
Fixes #806
[AIP SUP 025/2024](https://ais.nav.pt/wp-content/uploads/AIS_Files/eAIP_Current/eAIP_Online/eAIP/html/eSUP/LP-eSUP-A-2024-025-en-PT.html)

<html><body>
<!--StartFragment--><pre>
A2299/24 | Created 24/06/2024 14:18
-- | --
Q) LPPC/QCMXX/IV/M/A/000/999/4114N00841W005
A) LPPR  B) FROM: 24/06/24 14:18  TO: 24/12/31 23:59 EST

E) REF AIP SUP 025/2024 - LPPR AD - PORTO SURFACE SURVEILLANCE SYSTEM (A-SMGCS) DOWNGRADED, NEW END OF VALIDITY 2412312359EST.

</pre><!--EndFragment-->
</body>
</html>

[AIP SUP 063/2024](https://ais.nav.pt/wp-content/uploads/AIS_Files/eAIP_Current/eAIP_Online/eAIP/html/eSUP/LP-eSUP-A-2024-063-en-PT.html)

Disabled:

- Area Penetration Monitoring
- Runway Incursion Monitoring
- Runway Usage Monitoring
- Restriction Violation Monitoring